### PR TITLE
Only declare module the first time

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,6 +61,7 @@ function compile_html (file, opts) {
   });
 
   var result = "angular.module('"+opts.module+"'"+(opts.standalone?',[]':'')+").run(['$templateCache', function($templateCache) {\n" + compiled_templates.join('\n') + "\n}]);";
+  opts.standalone && (opts.standalone = false); //Only declare module the first time
 
   return result;
 };


### PR DESCRIPTION
Each time the dependency array is written, it declares a new module. Needs to only happen once.
